### PR TITLE
Decompose some GitHub Actions workflow steps into external actions

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -207,7 +207,6 @@ jobs:
       - name: Run pishrink
         run: |
           wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
-          chmod a+x pishrink.sh
           sudo ./pishrink.sh -za \
             ${{ steps.download-base.outputs.mountable_image }} \
             ${{ env.OUTPUT_IMAGE_NAME }}.img


### PR DESCRIPTION
This PR decomposes the following steps of the `build-os.yml` workflow (for building RPi OS SD card images) out to external GitHub actions:

- Shrinking the built image with pishrink: [ethanjli/pishrink-action](https://github.com/marketplace/actions/run-pishrink)